### PR TITLE
update deprecated action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v3.1.0
       - name: Azure login
         if: matrix.os-name == 'Windows'
-        uses: azure/login@v1.3.0
+        uses: azure/login@v1.4.7
         with:
           creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
       - name: Run

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Particular/setup-oracle-action#readme",
   "dependencies": {
-    "@actions/core": "^1.9.1",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.0",
     "dotenv": "^16.0.1",
     "npm-watch": "^0.11.0"


### PR DESCRIPTION
As part of GitHub Actions: save-state and set-output are deprecated #1135, this PR updates to Node16 and removes deprecated actions